### PR TITLE
Point the travis-ci badge at rust-lang/glacier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A big ‘ol pile of ICE.
 
-[![Build Status](https://travis-ci.org/steveklabnik/glacier.svg?branch=master)](https://travis-ci.org/steveklabnik/glacier)
+[![Build Status](https://travis-ci.org/rust-lang/glacier.svg?branch=master)](https://travis-ci.org/rust-lang/glacier)
 
 This repository is used to test internal compiler errors (also known as ICEs)
 in [Rust]. An ICE means that something went wrong, something unexpected. As


### PR DESCRIPTION
As the repo URL changed recently