### PR TITLE
Add feature gate to 61455

### DIFF
--- a/ices/61455.rs
+++ b/ices/61455.rs
@@ -1,4 +1,5 @@
 #![feature(const_generics)]
+#![feature(const_compare_raw_pointers)]
 
 use std::mem::transmute;
 


### PR DESCRIPTION
It's still an ICE but needs `#![feature(const_compare_raw_pointers)]` feature gate.