### PR TITLE
Only run labeler on rust-lang/glacier

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'rust-lang/glacier'
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Avoids build failures in forks