### PR TITLE
Display fixed ICE file contents in autofix PRs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,15 +114,22 @@ impl TestResult {
         }
     }
 
-    pub fn issue_url(&self) -> Option<String> {
-        let file_name = self.path().file_name()?.to_str()?;
+    pub fn issue_url(&self) -> String {
+        let file_name = self.path().file_name().unwrap().to_str().unwrap();
 
-        let issue_number = file_name.split(|ch: char| !ch.is_ascii_digit()).next()?;
+        let issue_number = file_name
+            .split(|ch: char| !ch.is_ascii_digit())
+            .next()
+            .unwrap();
 
-        Some(format!(
-            "https://github.com/rust-lang/rust/issues/{}",
-            issue_number
-        ))
+        format!("https://github.com/rust-lang/rust/issues/{}", issue_number)
+    }
+
+    pub fn syntax(&self) -> &'static str {
+        match self.ice.mode {
+            TestMode::ShellScript => "bash",
+            TestMode::SingleFile => "rust",
+        }
     }
 }
 


### PR DESCRIPTION
Because the files are moved, GitHub doesn't display file contents in the
"Files changed" tab: https://github.com/rust-lang/glacier/pull/209/files

So this PR displays them in a codeblock in the PR body to save a couple
clicks