### PR TITLE
Use minimal rustup profile in CI

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -2,7 +2,7 @@ name: Autofix
 
 on:
   schedule:
-  - cron: '0 12 * * *'
+    - cron: "0 12 * * *"
 
 jobs:
   build:
@@ -10,11 +10,13 @@ jobs:
     if: github.repository == 'rust-lang/glacier'
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Configure Git
-      run: |
-        git config --global user.name "rustbot"
-        git config --global user.email "rustbot@users.noreply.github.com"
-    - run: cargo run -p autofix
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v1
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "rustbot"
+          git config --global user.email "rustbot@users.noreply.github.com"
+
+      - run: cargo run -p autofix
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -17,6 +17,11 @@ jobs:
           git config --global user.name "rustbot"
           git config --global user.email "rustbot@users.noreply.github.com"
 
+      - name: Configure rustup
+        run: |
+          rustup set profile minimal
+          rustup toolchain install nightly
+
       - run: cargo run -p autofix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,9 +11,9 @@ jobs:
     if: github.repository == 'rust-lang/glacier'
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Cargo run labeler
-      run: cargo run -p labeler
-      env:
-        LABEL_TOKEN: ${{ secrets.LABEL_TOKEN }}
+      - name: Cargo run labeler
+        run: cargo run -p labeler
+        env:
+          LABEL_TOKEN: ${{ secrets.LABEL_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: Configure rustup
+        run: |
+          rustup set profile minimal
+          rustup toolchain install nightly
+
       - name: cargo run glacier
         run: cargo run
 


### PR DESCRIPTION
I was wondering why we got a bunch of PRs at once yesterday and it turns autofix had been repeatedly testing `nightly-2015-11-25` for the prior 12 or so days. Whoops.

The problem was clippy was not available on those nightlies, so [rustup fell back to a nightly where it was available](https://github.com/rust-lang/glacier/commit/75bf60fbed15e1f5d34640f7f2f56212530dc8e7/checks?check_suite_id=341584178#step:4:6)

The minimal profile doesn't include extra components, just `rustc`, `rust-std` and `cargo` which conveniently is exactly what we need