### PR TITLE
Replace null bytes in commit message descriptions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'rust-lang/glacier'
 
+    env:
+      RUST_LIB_BACKTRACE: 1
+
     steps:
       - uses: actions/checkout@v1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,6 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "autofix"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glacier 0.1.0",
  "once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -340,6 +346,7 @@ dependencies = [
 name = "glacier"
 version = "0.1.0"
 dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1455,6 +1462,7 @@ dependencies = [
 [metadata]
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
+"checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "690a62be8920ccf773ee00ef0968649b0e724cda8bd5b12286302b4ae955fdf5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.26"
 rayon = "1.2.0"
 tempfile = "3.1.0"
 

--- a/autofix/Cargo.toml
+++ b/autofix/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0.26"
 glacier = { path = ".." }
 once_cell = "1.2.0"
 reqwest = "0.9.21"

--- a/autofix/src/github.rs
+++ b/autofix/src/github.rs
@@ -1,7 +1,8 @@
+use anyhow::Result;
 use once_cell::sync::Lazy;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::env::{var, VarError};
+use std::env::var;
 
 static CLIENT: Lazy<Client> = Lazy::new(Client::new);
 
@@ -11,7 +12,7 @@ pub(crate) struct Config {
 }
 
 impl Config {
-    pub(crate) fn from_env() -> Result<Self, VarError> {
+    pub(crate) fn from_env() -> Result<Self> {
         Ok(Self {
             token: var("GITHUB_TOKEN")?,
             repo: var("GITHUB_REPOSITORY")?,
@@ -40,10 +41,7 @@ struct PullRequest {
     html_url: String,
 }
 
-pub(crate) fn pull_request(
-    config: &Config,
-    options: &PullRequestOptions,
-) -> Result<String, reqwest::Error> {
+pub(crate) fn pull_request(config: &Config, options: &PullRequestOptions) -> Result<String> {
     let url = format!("https://api.github.com/repos/{}/pulls", config.repo);
 
     let pr: PullRequest = CLIENT

--- a/autofix/src/main.rs
+++ b/autofix/src/main.rs
@@ -1,17 +1,17 @@
 mod fix;
 mod github;
 
+use anyhow::{Context, Result};
 use fix::fix;
 use glacier::rayon::prelude::*;
 use glacier::{test_all, Outcome};
-use std::error::Error;
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     let config = github::Config::from_env()?;
 
     test_all()?
-        .collect::<Result<Vec<_>, _>>()?
+        .collect::<Result<Vec<_>>>()?
         .into_iter()
         .filter(|result| result.outcome() != Outcome::ICEd)
-        .try_for_each(|result| fix(&result, &config))
+        .try_for_each(|result| fix(&result, &config).context(result))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ impl TestResult {
             out.push_str(self.stderr());
             out.push_str("==============");
 
-            Some(out)
+            Some(out.replace('\0', "NUL"))
         } else {
             None
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
+use anyhow::{bail, Result};
 use glacier::Outcome;
 use rayon::prelude::*;
-use std::error::Error;
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> Result<()> {
     let failed = glacier::test_all()?
-        .map(|res| -> Result<bool, String> {
+        .map(|res| -> Result<bool> {
             let result = res?;
             println!("{}", result);
 
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .try_reduce(|| false, |a, b| Ok(a || b))?;
 
     if failed {
-        Err("some ICEs are now fixed!".into())
+        bail!("some ICEs are now fixed!");
     } else {
         Ok(())
     }


### PR DESCRIPTION
Commit messages cannot have null bytes in them, but the diagnostics print out of 

https://github.com/rust-lang/glacier/blob/fe71d4d820940602a4d704f45e95a66b1886d9ee/ices/66473.rs#L1-L2

Included some, so autofix [stalled](https://github.com/rust-lang/glacier/commit/fe71d4d820940602a4d704f45e95a66b1886d9ee/checks?check_suite_id=397524525#step:5:274) after hitting that test

Also replaces `Result<_, Box<dyn Error>>`s with anyhow. I used it to track down the error with some nice backtraces/context