### PR TITLE
Set User-Agent for labeller

### DIFF
--- a/labeler/src/github.rs
+++ b/labeler/src/github.rs
@@ -4,7 +4,12 @@ use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::env::{var, VarError};
 
-static CLIENT: Lazy<Client> = Lazy::new(Client::new);
+static CLIENT: Lazy<Client> = Lazy::new(|| {
+    Client::builder()
+        .user_agent("rust-lang/glacier")
+        .build()
+        .unwrap()
+});
 
 pub(crate) struct Config {
     token: String,


### PR DESCRIPTION
reqwest 0.10 removes the default User-Agent, the GitHub API returns 403 Forbidden without one specified