### PR TITLE
Add some inline ASM crashes

### DIFF
--- a/ices/13368.rs
+++ b/ices/13368.rs
@@ -1,7 +1,7 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
     let arr: [u8; 16];
-    unsafe { asm!("" : "=m"(arr)); }
+    unsafe { llvm_asm!("" : "=m"(arr)); }
     println!("{:?}", arr);
 }

--- a/ices/13520.rs
+++ b/ices/13520.rs
@@ -1,9 +1,9 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main() {
     let x = ();
     unsafe {
         let p: *const () = &x;
-        asm!("" :: "r"(*p));
+        llvm_asm!("" :: "r"(*p));
     }
 }

--- a/ices/15402.rs
+++ b/ices/15402.rs
@@ -1,11 +1,11 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 #[repr(packed)]
 struct Bitfield<T>(T);
 
 fn test()->(Bitfield<u32>,Bitfield<u32>) {
     let mut out=(Bitfield(0),Bitfield(0));
-    unsafe{asm!("" : "={eax}"(out.0), "={ebx}"(out.1))};
+    unsafe{llvm_asm!("" : "={eax}"(out.0), "={ebx}"(out.1))};
     out
 }
 

--- a/ices/59184.rs
+++ b/ices/59184.rs
@@ -1,0 +1,31 @@
+#![feature(asm)]
+
+fn main()
+{
+    println!("Hello, world! {}", read_after_raising_any_exceptions());
+}
+
+#[inline(never)]
+pub fn read_after_raising_any_exceptions() -> u16
+{
+	unsafe
+	{
+		// See <https://github.com/HJLebbink/asm-dude/wiki/FSTCW_FNSTCW>.
+		let mut control_word: u16;
+		asm!
+		(
+			"fstcw $0"
+			:
+				// Output constraints.
+				"=m"(control_word)
+			:
+				// Input constraints.
+			:
+				// Clobbers.
+			:
+				// Options.
+				"volatile"
+		);
+		control_word
+	}
+}

--- a/ices/59184.rs
+++ b/ices/59184.rs
@@ -1,4 +1,4 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 fn main()
 {
@@ -12,7 +12,7 @@ pub fn read_after_raising_any_exceptions() -> u16
 	{
 		// See <https://github.com/HJLebbink/asm-dude/wiki/FSTCW_FNSTCW>.
 		let mut control_word: u16;
-		asm!
+		llvm_asm!
 		(
 			"fstcw $0"
 			:

--- a/ices/66223.sh
+++ b/ices/66223.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+rustc -C opt-level=3 - << 'END'
+#![feature(llvm_asm)]
+
+unsafe fn _mm512_set1_epi64(a: i64) {
+    llvm_asm! {
+        "vpbroadcastq zmm0{k1}, $0"
+        :: "m"(a)
+        :: "intel"
+    }
+}
+
+fn main() {
+    unsafe { _mm512_set1_epi64(123); }
+}
+END

--- a/ices/68136-1.rs
+++ b/ices/68136-1.rs
@@ -1,0 +1,9 @@
+#![feature(asm)]
+
+extern "C" fn foo() { }
+
+fn main() {
+    unsafe {
+        asm!("callq $0" :: "s"(foo) :: "volatile");
+    }
+}

--- a/ices/68136-1.rs
+++ b/ices/68136-1.rs
@@ -1,9 +1,9 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 extern "C" fn foo() { }
 
 fn main() {
     unsafe {
-        asm!("callq $0" :: "s"(foo) :: "volatile");
+        llvm_asm!("callq $0" :: "s"(foo) :: "volatile");
     }
 }

--- a/ices/68136-2.rs
+++ b/ices/68136-2.rs
@@ -1,11 +1,11 @@
-#![feature(asm)]
+#![feature(llvm_asm)]
 
 extern "C" fn foo() { }
 
 fn main() {
     let x: usize;
     unsafe {
-        asm!("movq $1, $0" : "=r"(x) : "r"(foo));
+        llvm_asm!("movq $1, $0" : "=r"(x) : "r"(foo));
     }
     assert!(x != 0);
 }

--- a/ices/68136-2.rs
+++ b/ices/68136-2.rs
@@ -1,0 +1,11 @@
+#![feature(asm)]
+
+extern "C" fn foo() { }
+
+fn main() {
+    let x: usize;
+    unsafe {
+        asm!("movq $1, $0" : "=r"(x) : "r"(foo));
+    }
+    assert!(x != 0);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ impl ICE {
             outcome: match output.status.code() {
                 Some(0) => Outcome::NoError,
                 Some(101) => Outcome::ICEd, // An ICE will cause an error code of 101
+                // Bash uses 128+N for processes terminated by signal N
+                Some(x) if x > 128 => Outcome::ICEd,
                 Some(_) => Outcome::Errored,
                 None => Outcome::ICEd, // If rustc receives a signal treat is as an ICE
             },


### PR DESCRIPTION
The second commit makes status codes > 128 be considered an ICE

Bash uses 128+N to express that a process was terminated by a signal N,
so this is needed for scripts such as 66223.sh that contain a command
that gets terminated
