### PR TITLE
Adds 3 llvm_asm! related ICEs

### DIFF
--- a/ices/29382.rs
+++ b/ices/29382.rs
@@ -1,0 +1,13 @@
+#![feature(llvm_asm)]
+unsafe fn test(x: *mut u32) {
+    llvm_asm!("": "=m" (*x));
+}
+
+fn main() {
+    let mut x = 5u32;
+    let r = &mut x as *mut u32;
+    
+    unsafe {
+        test(r);
+    }
+}

--- a/ices/30606.rs
+++ b/ices/30606.rs
@@ -1,0 +1,7 @@
+#![feature(llvm_asm)]
+
+fn f() {}
+
+fn main() {
+    unsafe {llvm_asm!( "" :: "r"(f))}
+}

--- a/ices/31437.rs
+++ b/ices/31437.rs
@@ -1,0 +1,13 @@
+#![feature(llvm_asm)]
+
+fn test() -> () {
+    unsafe {
+        let test: i32;
+        // using `str r0, [%0]` or any other instruction, it still crashes.
+        llvm_asm!("mov %0, r0" : "=m"(test) ::);
+    }   
+}
+
+fn main() {
+    test();
+}


### PR DESCRIPTION
These are all "compiler did not exit successfully" errors so they may need additional work to be cleared (or possibly #339 enables them) but they were previously discussed as, and it is my belief they would reasonably be considered, ICEs.