### PR TITLE
Compact output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "alphanumeric-sort"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37ce94154d73f6961f87571a3ab7814e1608f373bd55a933e3e771b6dd59fc4"
+
+[[package]]
 name = "anyhow"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +276,7 @@ dependencies = [
 name = "glacier"
 version = "0.1.0"
 dependencies = [
+ "alphanumeric-sort",
  "anyhow",
  "rayon",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+alphanumeric-sort = "1.0.11"
 anyhow = "1.0.26"
 rayon = "1.2.0"
 tempfile = "3.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,14 @@ impl TestResult {
         }
     }
 
+    pub fn outcome_token(&self) -> char {
+        match self.outcome {
+            Outcome::ICEd => '.',
+            Outcome::Errored => 'E',
+            Outcome::NoError => 'N',
+        }
+    }
+
     pub fn issue_url(&self) -> String {
         let file_name = self.path().file_name().unwrap().to_str().unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,11 @@ fn discover(dir: &str) -> Result<Vec<ICE>> {
         }
         ices.push(ICE::from_path(entry.path())?);
     }
+
+    ices.sort_unstable_by(|a, b| {
+        alphanumeric_sort::compare_os_str(&a.path.as_os_str(), &b.path.as_os_str())
+    });
+
     Ok(ices)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> Result<()> {
     }
 
     match failed.len() {
-        0 => eprintln!("Finished: No fixed ICEs"),
+        0 => eprintln!("\nFinished: No fixed ICEs"),
         len => bail!("{} ICEs are now fixed!", len)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,9 @@ fn main() -> Result<()> {
     }
 
     match failed.len() {
-        0 => Ok(()),
+        0 => eprintln!("Finished: No fixed ICEs"),
         len => bail!("{} ICEs are now fixed!", len)
     }
+
+    Ok(())
 }


### PR DESCRIPTION
In progress results are shown similar to rustc's tests, with `.`, `N`, `E` respectively meaning ICEd, fixed with no errors,  fixed with errors

The full error messages are then printed (in a sorted order) after the testing has finished, it'll look something this:

```
...........................N...................E.............................................................................................
ices/71344.rs: fixed with no errors
=== stdout ===
=== stderr ===
==============

ices/71471.rs: fixed with errors
=== stdout ===
=== stderr ===
error: expected `[`, found `B`
 --> /home/runner/work/glacier/glacier/ices/71471.rs:2:3
  |
2 | #!B
  |   ^ expected `[`

error: aborting due to previous error

==============
Error: 2 ICEs are now fixed!
```

Iooks a little odd here because code blocks don't wrap, but terminals and github actions will soft wrap the many dots