### PR TITLE
Tweak examples to show ICE as expected

### DIFF
--- a/ices/56445-2.rs
+++ b/ices/56445-2.rs
@@ -1,6 +1,8 @@
 #![feature(const_generics)]
+#![crate_type = "lib"]
+
 use core::marker::PhantomData;
 
 struct Bug<'a, const S: &'a str>(PhantomData<&'a ()>);
 
-impl Bug<'_, {""}> {}
+impl Bug<'_, ""> {}

--- a/ices/56445-3.rs
+++ b/ices/56445-3.rs
@@ -1,3 +1,5 @@
+#![crate_type = "lib"]
+
 pub struct Memory<'rom> {
     rom: &'rom [u8],
     ram: [u8; Self::SIZE],

--- a/ices/56445-4.rs
+++ b/ices/56445-4.rs
@@ -1,0 +1,23 @@
+#![crate_type = "lib"]
+
+use std::marker::PhantomData;
+
+struct S<'a>
+{
+    m1: PhantomData<&'a u8>,
+    m2: [u8; S::size()],
+}
+
+impl<'a> S<'a>
+{
+    const fn size() -> usize { 1 }
+
+    fn new() -> Self
+    {
+        Self
+        {
+            m1: PhantomData,
+            m2: [0; Self::size()],
+        }
+    }
+}


### PR DESCRIPTION
56445-2 requires to specify crate type. Also add the fourth example from the issue.
Closes #373