### PR TITLE
Tweak some examples

### DIFF
--- a/ices/74298.rs
+++ b/ices/74298.rs
@@ -1,0 +1,16 @@
+#![feature(type_alias_impl_trait)]
+
+type X<T> = impl Sized;
+
+fn f<T>() -> X<T> {}
+
+trait Y {
+    fn g(&self) {}
+}
+
+impl Y for X<()> {}
+impl Y for X<i32> {}
+
+fn main() {
+    f::<()>().g();
+}

--- a/ices/74299.rs
+++ b/ices/74299.rs
@@ -1,16 +1,23 @@
-#![feature(type_alias_impl_trait)]
+#![feature(specialization)]
 
-type X<T> = impl Sized;
+trait X {
+    type U;
+    fn f(&self) -> Self::U {
+        loop {}
+    }
+}
 
-fn f<T>() -> X<T> {}
+impl<T> X for T {
+    default type U = ();
+}
 
 trait Y {
     fn g(&self) {}
 }
 
-impl Y for X<()> {}
-impl Y for X<i32> {}
+impl Y for <() as X>::U {}
+impl Y for <i32 as X>::U {}
 
 fn main() {
-    f::<()>().g();
+    ().f().g();
 }

--- a/ices/74307.rs
+++ b/ices/74307.rs
@@ -1,5 +1,0 @@
-struct Matrix<const ROWS: usize, const COLS: usize> {
-    elements: [f64; ROWS * COLS],
-}
-
-fn main() {}


### PR DESCRIPTION
- rust-lang/rust#74307 is now closed as duplicated
- Fix some examples that mixed up (rust-lang/rust#74298 and rust-lang/rust#74299)
