### PR TITLE
Re-add rust-lang/rust#71546 with another MCVE

### DIFF
--- a/ices/71546-2.rs
+++ b/ices/71546-2.rs
@@ -1,0 +1,14 @@
+pub fn serialize_as_csv<V>(value: &V) -> Result<String, &str>
+where
+    V: 'static,
+    for<'a> &'a V: IntoIterator,
+    for<'a> <&'a V as IntoIterator>::Item: ToString + 'static,
+{
+    let csv_str: String = value
+        .into_iter()
+        .map(|elem| elem.to_string())
+        .collect::<String>();
+    Ok(csv_str)
+}
+
+fn main() {}


### PR DESCRIPTION
We were tracking this issue with https://github.com/rust-lang/rust/issues/71546#issuecomment-620638437 but the original code has another ICE. This uses another MCVE that seem to have the same cause as the original.