### PR TITLE
Retrieve both open and closed issues from GitHub

### DIFF
--- a/labeler/src/github.rs
+++ b/labeler/src/github.rs
@@ -48,7 +48,7 @@ pub(crate) fn get_labeled_issues(
     label_name: String,
 ) -> Result<Vec<Issue>, reqwest::Error> {
     let url = format!(
-        "https://api.github.com/repos/rust-lang/rust/issues?labels={}",
+        "https://api.github.com/repos/rust-lang/rust/issues?labels={}&state=all",
         label_name
     );
 
@@ -64,7 +64,7 @@ pub(crate) fn get_labeled_issues(
     if pages > 1 {
         for i in 2..=pages {
             let url = format!(
-                "https://api.github.com/repos/rust-lang/rust/issues?labels={}&page={}",
+                "https://api.github.com/repos/rust-lang/rust/issues?labels={}&state=all&page={}",
                 label_name, i
             );
             let mut paged_issues: Vec<Issue> = CLIENT


### PR DESCRIPTION
By default the `/issues` query returns only open issues. Ask for
both open and closed issues to avoid relabelling already closed issues.

https://developer.github.com/v3/issues/#parameters