### PR TITLE
Update `actions/checkout` to v2

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,7 +13,7 @@ jobs:
       RUST_LIB_BACKTRACE: 1
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Configure Git
         run: |

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'rust-lang/glacier'
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Configure rustup
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Configure rustup
         run: |


### PR DESCRIPTION
> github actions seems to be quite slow recently

This may resolve the above issue since some runs fail on checkout e.g. https://github.com/rust-lang/glacier/runs/1482152031