### PR TITLE
Post issue numbers when ICE is added/changed

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -1,0 +1,29 @@
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get issue numbers
+        run: |
+          git diff origin/${GITHUB_BASE_REF}..origin/${GITHUB_HEAD_REF} \
+            --diff-filter=AM \
+            --name-only -- ices | grep -o '[0-9]*' >> comments
+          sed -i 's/^/- github.com\/rust-lang\/rust\/issues\/ /g' comments
+          sed -i -z 's/\n/\\n/g' comments
+
+      - name: Post issue numbers
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          URL: ${{ github.event.pull_request.comments_url }}
+        run: |
+          curl -X POST \
+              -H "Authorization: token ${GITHUB_TOKEN}" \
+              -d "{\"body\": \"$(cat comments)\"}" \
+              ${URL}


### PR DESCRIPTION
This posts a comment with issue numbers that PR adds/changes, like: https://github.com/JohnTitor/glacier/pull/1#issuecomment-743719174

For example, let's consider the case where we look at each issue added by #562. We want to visit each issue for review, but there is no link there, which is inconvenient.
This would resolve that issue, when a PR adds `#1337` and `#1338`, the bot comments there, like:
```markdown
- github.com/rust-lang/rust/issues/ 1337
- github.com/rust-lang/rust/issues/ 1338
```
Now we can copy-paste those (broken) links and visit issues easily.
Note that whitespace is added before issue numbers not to reference the issue on GitHub. I'd like to avoid making the issue thread longer meaninglessly.