### PR TITLE
Fix git push failing in autofix

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Seems like something changed ~2 days ago and actions/checkout only
fetches the latest commit now. Creating the commit suceeds but the push
fails because it needs to read (seemingly 1) prior commits

A fetch depth of 2 would probably be sufficient, but to be safe I've set
it to fetch the entire history