### PR TITLE
Bump `mir-opt-level` up 2 to 3 and 3 to 4

### DIFF
--- a/fixed/67019.sh
+++ b/fixed/67019.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc +nightly --edition 2018 -Z mir-opt-level=2 - << EOF
+rustc +nightly --edition 2018 -Z mir-opt-level=3 - << EOF
 fn test(this: ((u8, u8),)) {
     assert!((this.0).1 == 0);
 }

--- a/fixed/68296.sh
+++ b/fixed/68296.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc -Zmir-opt-level=2 - << END
+rustc -Zmir-opt-level=3 - << END
 const FOO: *const u32 = { //~ ERROR any use of this value will cause an error
     let x = 42;
     &x

--- a/fixed/68841.sh
+++ b/fixed/68841.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc -Z mir-opt-level=2 --edition 2018 - << END
+rustc -Z mir-opt-level=3 --edition 2018 - << END
 #![feature(async_closure)]
 
 use std::future::Future;

--- a/fixed/71793.sh
+++ b/fixed/71793.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc +nightly --edition 2018 -Z mir-opt-level=2 - << EOF
+rustc +nightly --edition 2018 -Z mir-opt-level=3 - << EOF
 pub async fn connect() {}
 pub fn block_on<F: std::future::Future>(_: F) {}
 fn main() {

--- a/fixed/72181.sh
+++ b/fixed/72181.sh
@@ -19,4 +19,4 @@ fn main() {
 
 EOF
 
-rustc -Zmir-opt-level=2 --emit=mir 72181.rs
+rustc -Zmir-opt-level=3 --emit=mir 72181.rs

--- a/fixed/72285.sh
+++ b/fixed/72285.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc -Z mir-opt-level=3 - << EOF
+rustc -Z mir-opt-level=4 - << EOF
 
 fn main() {
     let i = (0..usize::max_value()).chain(0..10).skip(usize::max_value());

--- a/fixed/72372.sh
+++ b/fixed/72372.sh
@@ -8,4 +8,4 @@ fn main() {
 
 EOF
 
-rustc -Zmir-opt-level=2 72372.rs
+rustc -Zmir-opt-level=3 72372.rs

--- a/fixed/72679.sh
+++ b/fixed/72679.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc -Z mir-opt-level=2 - << EOF
+rustc -Z mir-opt-level=3 - << EOF
 
 #![cfg_attr(const_fn, feature(const_fn))]
 

--- a/fixed/73327.sh
+++ b/fixed/73327.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc -Z mir-opt-level=2 - << EOF
+rustc -Z mir-opt-level=3 - << EOF
 
 fn load<R>(_r: R) {}
 

--- a/fixed/75053.sh
+++ b/fixed/75053.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc -Zmir-opt-level=2 - << EOF
+rustc -Zmir-opt-level=3 - << EOF
 #![feature(type_alias_impl_trait)]
 
 use std::marker::PhantomData;

--- a/fixed/75299.sh
+++ b/fixed/75299.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc -Z mir-opt-level=3 - << EOF
+rustc -Z mir-opt-level=4 - << EOF
 #![feature(const_generics, box_syntax)]
 #![allow(incomplete_features)]
 

--- a/fixed/76375.sh
+++ b/fixed/76375.sh
@@ -29,5 +29,5 @@ pub async fn h() {}
 
 EOF
 
-rustc --edition=2018 -Zmir-opt-level=2 -Zunsound-mir-opts x.rs
-rustc --edition=2018 -Zmir-opt-level=2 y.rs --extern x -L.
+rustc --edition=2018 -Zmir-opt-level=3 -Zunsound-mir-opts x.rs
+rustc --edition=2018 -Zmir-opt-level=3 y.rs --extern x -L.

--- a/fixed/77911.sh
+++ b/fixed/77911.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc -Z mir-opt-level=2 - << EOF
+rustc -Z mir-opt-level=3 - << EOF
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 

--- a/fixed/78442.sh
+++ b/fixed/78442.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc -Z mir-opt-level=2 - << EOF
+rustc -Z mir-opt-level=3 - << EOF
 #![crate_type = "lib"]
 
 // Error won't happen if "bar" is not generic

--- a/fixed/80060.sh
+++ b/fixed/80060.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc -Z mir-opt-level=2 -Z instrument-coverage - <<EOF
+rustc -Z mir-opt-level=3 -Z instrument-coverage - <<EOF
 pub fn main() {
     let c = || {};
     c();

--- a/ices/73021.sh
+++ b/ices/73021.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc --emit mir -Z mir-opt-level=2 - <<EOF
+rustc --emit mir -Z mir-opt-level=3 - <<EOF
 // build-pass
 #![allow(dead_code)]
 trait Foo {

--- a/ices/81403.sh
+++ b/ices/81403.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rustc --emit=mir -Zmir-opt-level=2 - <<'EOF'
+rustc --emit=mir -Zmir-opt-level=3 - <<'EOF'
 // build-pass
 pub trait Foo<'a> {
     type Bar;


### PR DESCRIPTION
Caused by rust-lang/rust#82736.
Closes #679 and closes #680 but other snippets are updated as well.