### PR TITLE
Add aarch64-apple-darwin target to CI

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "nightly"
+targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly"
 targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin"]
+profile = "minimal"


### PR DESCRIPTION
Per the discussion in #754, I decided to convert the toolchain file to the newer TOML format. This facilitates adding other targets, as some ICEs cannot be triggered with the default `x86_64-unknown-linux-gnu` target.
