### PR TITLE
Install `aarch64-apple-darwin` toolchain on autofix

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           rustup set profile minimal
           rustup toolchain install nightly
+          # aarch64-apple-darwin is needed for issue-84020
+          rustup target add --toolchain nightly aarch64-apple-darwin
 
       - run: cargo run -p autofix
         env:


### PR DESCRIPTION
Closes #765