### PR TITLE
Use `[patch.crates-io]` section instead of path key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ members = [
     "autofix",
     "labeler"
 ]
+
+[patch.crates-io]
+glacier = { path = "." }

--- a/autofix/Cargo.toml
+++ b/autofix/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.26"
-glacier = { path = ".." }
+glacier = "0.1.0"
 once_cell = "1.2.0"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0.101", features = ["derive"] }


### PR DESCRIPTION
This should make things easy when the directory structure becomes complex.