### PR TITLE
Treat linker errors as ICEs

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           rustup set profile minimal
           rustup toolchain install nightly
-          # aarch64-apple-darwin is needed for issue-84020
+          # aarch64-apple-darwin is needed for issue-84020 and issue-84984
           rustup target add --toolchain nightly aarch64-apple-darwin
 
       - run: cargo run -p autofix

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           rustup set profile minimal
           rustup toolchain install nightly
-          # aarch64-apple-darwin is needed for 84020
+          # aarch64-apple-darwin is needed for issue-84020 and issue-84984
           rustup target add --toolchain nightly aarch64-apple-darwin
 
       - name: cargo run glacier

--- a/ices/84984.sh
+++ b/ices/84984.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+rustc --target aarch64-apple-darwin - <<'EOF'
+use std::{fs::File, io::Read, env::args};
+
+fn main() -> ! {
+    let args:Vec<String> = args().collect();
+    if args.len() < 2 {
+        panic!("Not enough arguments!")
+    }
+    // FIXME: Code makes bad assumption that first arg
+    // will always be the file.
+    let mut f = File::open(&args[1]).unwrap();
+    // String gets written to by .read_to_string()
+    let mut file = String::new();
+    // TODO: Implement some proper error handling
+    f.read_to_string(&mut file).unwrap();
+    // Drop file handle. From now on, it's unnecessary.
+    drop(f);
+    // Make 'file' immutable (There HAS to be a better way of doing this!)
+    let file = file;
+    println!("{}", file);
+    todo!("Do something with file")
+}
+EOF

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,9 @@ impl ICE {
             ice: self,
             outcome: match output.status.code() {
                 _ if stderr.contains("error: internal compiler error") => Outcome::ICEd,
+                Some(x) if x != 0 && stderr.contains("error: linking with `cc` failed") => {
+                    Outcome::ICEd
+                }
                 Some(0) => Outcome::NoError,
                 Some(101) => Outcome::ICEd, // An ICE will cause an error code of 101
                 // Bash uses 128+N for processes terminated by signal N


### PR DESCRIPTION
This treats linker errors exactly as though they were ICEs. Should they be treated differently?

If accepted, this PR will close #731.
