### PR TITLE
Ignore recently closed issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +446,7 @@ dependencies = [
 name = "labeler"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "glacier",
  "once_cell",
  "regex",
@@ -559,6 +574,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -943,6 +977,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/labeler/Cargo.toml
+++ b/labeler/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = { version = "0.4.19", features = ["serde"] }
+glacier = "0.1.0"
 once_cell = "1"
 regex = "1"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1", features = ["derive"] }
-glacier = "0.1.0"

--- a/labeler/src/github.rs
+++ b/labeler/src/github.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use once_cell::sync::{Lazy, OnceCell};
 use regex::Regex;
 use reqwest::blocking::Client;
@@ -158,6 +159,7 @@ pub(crate) struct Issue {
     pub(crate) number: usize,
     pub(crate) title: String,
     pub(crate) state: IssueState,
+    pub(crate) closed_at: DateTime<Utc>,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Eq)]

--- a/labeler/src/main.rs
+++ b/labeler/src/main.rs
@@ -1,3 +1,5 @@
+use chrono::{Duration, Utc};
+
 use crate::github::IssueState;
 
 mod github;
@@ -19,7 +21,8 @@ fn main() {
     let mut labeled_issue_numbers: Vec<usize> = Vec::new();
     let mut closed_issue_numbers: Vec<usize> = Vec::new();
     for i in issues.unwrap() {
-        if i.state == IssueState::Closed && tested_issue_list.contains(&i.number) {
+        let recently_closed = (Utc::now() - i.closed_at) < Duration::days(3);
+        if i.state == IssueState::Closed && !recently_closed && tested_issue_list.contains(&i.number) {
             closed_issue_numbers.push(i.number);
         }
         labeled_issue_numbers.push(i.number);


### PR DESCRIPTION
Prevents prematurely opening issues before they can be autofixed