### PR TITLE
Run on stable, enable build cache in CI

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,36 @@
+name: Build
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure rustup
+      id: rustup
+      run: |
+        rustup update
+        rustup toolchain install --profile minimal nightly
+        rustup target add --toolchain nightly x86_64-pc-windows-msvc
+      shell: bash
+
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          autofix/
+          labeler/
+          src/
+          target/
+        key: build-${{ github.run_id }}
+        restore-keys: build-
+
+    # We restore source files from the cache to keep their modification times,
+    # then use git to undo that for files that have actually changed. This
+    # prevents unnecessary rebuilds
+    - run: |
+        git status
+        git checkout .
+        git clean -f .
+      shell: bash
+
+    - run: cargo build --release --workspace --locked
+      shell: bash

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 12 * * *"
 
 jobs:
-  build:
+  autofix:
     runs-on: ubuntu-latest
     if: github.repository == 'rust-lang/glacier'
 
@@ -22,12 +22,9 @@ jobs:
           git config --global user.name "rustbot"
           git config --global user.email "rustbot@users.noreply.github.com"
 
-      - name: Configure rustup
-        run: |
-          rustup set profile minimal
-          rustup toolchain install nightly
-          rustup target add x86_64-pc-windows-msvc
+      - name: Build
+        uses: ./.github/actions/build
 
-      - run: cargo run -p autofix
+      - run: ./target/release/autofix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,20 +6,17 @@ on:
       - master
 
 jobs:
-  build:
+  label:
     runs-on: ubuntu-latest
     if: github.repository == 'rust-lang/glacier'
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Configure rustup
-        run: |
-          rustup set profile minimal
-          rustup toolchain install nightly
+      - name: Build
+        uses: ./.github/actions/build
 
-      - name: Cargo run labeler
-        run: cargo run -p labeler
+      - run: ./target/release/labeler
         env:
           LABEL_TOKEN: ${{ secrets.LABEL_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,23 +3,13 @@ name: Continuous Integration
 on: [push, pull_request]
 
 jobs:
-  build:
+  main:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Configure rustup
-        run: |
-          rustup set profile minimal
-          rustup toolchain install nightly
-          rustup target add x86_64-pc-windows-msvc
+      - name: Build
+        uses: ./.github/actions/build
 
-      - name: cargo run glacier
-        run: cargo run
-
-      - name: cargo check autofix
-        run: cargo check -p autofix
-
-      - name: cargo check labeler
-        run: cargo check -p labeler
+      - run: ./target/release/glacier

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the odd code path, even if the point of the change wasn’t to fix the bug.
 
 As such, this repository is a collection of these bugs, and it runs on Rust
 nightly, once a day, through GitHub Actions. If any of the ICEs stop happening, the build
-will fail, and I can close the associated bug.
+will fail, and we can close the associated bug.
 
 ## Helping out
 
@@ -23,7 +23,7 @@ Contributing to Glacier is fairly easy:
 2. Pick one.
 3. Create a file in `ices/` with the same digit as the bug.
 4. Copy the code that causes the ICE into your new file.
-5. (optional) Verify it works by running `cargo run` to run the tests.
+5. (optional) Verify it works by running `rustup update nightly`, then `cargo run` to run the tests.
 6. Send a pull request!
 
 Note: Running this on Windows may give false positives and report some ICEs as fixed,

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly


### PR DESCRIPTION
Saves a good minute+ on each action

This also means locally you don't have to rebuild anything to run glacier again the next day