### PR TITLE
ci: autofix: run earlier wrt nightly release time

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -2,7 +2,7 @@ name: Autofix
 
 on:
   schedule:
-    - cron: "0 12 * * *"
+    - cron: "0 3 * * *"
 
 jobs:
   autofix:


### PR DESCRIPTION
We don't actually have to wait ~half a day after nightly is released