### PR TITLE
Do not use tab characters

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: tab character check
-        run: if grep -P '\t' -r ices/* fixed/*; then exit 1; fi
+        run: if grep -P '\t' -rn --color ices fixed; then exit 1; fi
 
       - name: Build
         uses: ./.github/actions/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: tab character check
+        run: if grep -P '\t' -r ices/* fixed/*; then exit 1; fi
+
       - name: Build
         uses: ./.github/actions/build
 

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -192,7 +192,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+   http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/fixed/94629.rs
+++ b/fixed/94629.rs
@@ -1,6 +1,6 @@
 impl A for B {
-	fn a(){{{{({{{ExprKind::Use {});(]),}}
-	fn b()  {c!(<> []))}
+    fn a(){{{{({{{ExprKind::Use {});(]),}}
+    fn b()  {c!(<> []))}
 
 #[rustc_legacy_const_generics(2)]
 pub unsafe fn c<>() -> () {}

--- a/ices/93022.rs
+++ b/ices/93022.rs
@@ -1,4 +1,4 @@
-#![recursion_limit="256000"]
+#![recursion_limit = "256000"]
 
 struct Z;
 struct S<T>(T);
@@ -36,7 +36,7 @@ type x16 = SumOf<x8, x8>;
 type x32 = SumOf<x16, x16>;
 type x64 = SumOf<x32, x32>;
 type x128 = SumOf<x64, x64>;
-// 
+//
 
 trait NumericValue {
     const VALUE: usize;
@@ -48,13 +48,11 @@ impl NumericValue for Z {
 
 impl<N> NumericValue for S<N>
 where
-	N: NumericValue,
+    N: NumericValue,
 {
     const VALUE: usize = N::VALUE + 1;
-} 
+}
 
 const value: usize = <x16 as NumericValue>::VALUE;
 
-fn main() {
-  
-}
+fn main() {}

--- a/ices/93946.sh
+++ b/ices/93946.sh
@@ -26,27 +26,27 @@ cat > subcrate/src/lib.rs <<'EOF'
 #[derive(PartialEq, Eq)]
 pub struct Const {}
 impl Const {
-	pub const fn func(self) -> usize { 1 }
+    pub const fn func(self) -> usize { 1 }
 }
 
 pub struct Foo<const C: Const>
 where
-	[(); C.func()]: Sized
+    [(); C.func()]: Sized
 {}
 
 pub trait Bar {
-	type Associated;
-	fn associated() -> Self::Associated;
+    type Associated;
+    fn associated() -> Self::Associated;
 }
 
 impl<const C: Const> Bar for Foo<C>
 where
-	[(); C.func()]: Sized
+    [(); C.func()]: Sized
 {
-	type Associated = [(); C.func()];
-	fn associated() -> Self::Associated {
-		[(); C.func()]
-	}
+    type Associated = [(); C.func()];
+    fn associated() -> Self::Associated {
+        [(); C.func()]
+    }
 }
 EOF
 
@@ -54,7 +54,7 @@ cat > src/main.rs <<'EOF'
 use subcrate::*;
 
 fn main() {
-	<Foo::<{Const{}}> as Bar>::associated();
+    <Foo::<{Const{}}> as Bar>::associated();
 }
 EOF
 

--- a/ices/96818.rs
+++ b/ices/96818.rs
@@ -1,13 +1,13 @@
 macro_rules! values {
-	($($token:ident($value:literal) $(as $inner:ty)? => $attr:meta,)*) => {
-		#[derive(Debug)]
-		pub enum TokenKind {
-			$(
-				#[$attr]
-				$token $($inner)? = $value,
-			)*
-		}
-	};
+    ($($token:ident($value:literal) $(as $inner:ty)? => $attr:meta,)*) => {
+        #[derive(Debug)]
+        pub enum TokenKind {
+            $(
+                #[$attr]
+                $token $($inner)? = $value,
+            )*
+        }
+    };
 }
 
 values!(STRING(1) as (String) => cfg(test),);


### PR DESCRIPTION
When I add a regression test, I often copy-paste examples from glacier PRs' OP if it's referenced to an issue, as it's mostly simplified and has `fn main() {}`.
However the tab characters (`\t`) aren't allowed on rust-lang/rust thus it's inconvenient if glacier code has them.
This adds a CI check not to contain and replaces them on current code with whitespaces.