### PR TITLE
Upgrade some actions to v3

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -11,7 +11,7 @@ runs:
         rustup target add --toolchain nightly x86_64-pc-windows-msvc
       shell: bash
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/.cargo/registry/index/

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,7 +13,7 @@ jobs:
       RUST_LIB_BACKTRACE: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'rust-lang/glacier'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build
         uses: ./.github/actions/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: tab character check
         run: if grep -P '\t' -rn --color ices fixed; then exit 1; fi


### PR DESCRIPTION
There shouldn't be any visible changes, see https://github.com/actions/checkout/releases/tag/v3.0.0 and https://github.com/actions/cache/releases/tag/v3.0.0