### PR TITLE
Replace duplicate of 99777-2

### DIFF
--- a/ices/99777-1.rs
+++ b/ices/99777-1.rs
@@ -1,4 +1,6 @@
 pub fn test() {
-    #[doc(alias = "test")]
-    let num_flags = 0;
+  #[doc(alias = "test")]
+  {
+      println!("Hello, world!");
+  }
 }


### PR DESCRIPTION
Replacement is the first example in rust-lang/rust#99777